### PR TITLE
Fix timeout_add	for dovecot 2.2.26 and later.

### DIFF
--- a/drac-plugin.c
+++ b/drac-plugin.c
@@ -98,7 +98,7 @@ static void drac_mail_user_created(struct mail_user *user)
         drac_timeout(NULL);
 #undef timeout_add
 #define timeout_add(msecs, callback, context) \
-        timeout_add(msecs, __LINE__, callback, context)
+        timeout_add(msecs, __FILE__, __LINE__, callback, context)
         to_drac = timeout_add(1000*dractout, drac_timeout, NULL);
     } else {
         i_error("%s: Only IPv4 and IPv6 addresses are supported", __FUNCTION__);


### PR DESCRIPTION
Dovecot	commit dfa23b2ddc43f323112225facf7cd7191e62e02c	changed	the timeout
function for v2.2.26 and later to also contain the filename.

Add the __FILE__ macro to make it work.

Signoff-By: Andreas Thienemann <andreas@bawue.net>