### PR TITLE
Update use of user->remote_ip for Dovecot 2.3 API change

### DIFF
--- a/drac-plugin.c
+++ b/drac-plugin.c
@@ -42,12 +42,12 @@ static void drac_timeout(void *context ATTR_UNUSED)
     struct ip_addr ipv4 = ip;
 
     if (IPADDR_IS_V4(&ipv4) || (net_ipv6_mapped_ipv4_convert(&ip, &ipv4) == 0)) {
-        i_info("drac_timeout() IP is ipv4(%s)",net_ip2addr(&ipv4));
+        i_debug("drac_timeout() IP is ipv4(%s)",net_ip2addr(&ipv4));
         if (dracauth(drachost, (unsigned long) ipv4.u.ip4.s_addr, &err) != 0) {
             i_error("%s: dracauth() failed: %s", __FUNCTION__, err);
         }
     } else if(IPADDR_IS_V6(&ip)) {
-        i_info("drac_timeout() IP is ipv6(%s)",net_ip2addr(&ip));
+        i_debug("drac_timeout() IP is ipv6(%s)",net_ip2addr(&ip));
         if (dracauth6(drachost, (const unsigned char *) &ip.u.ip6.s6_addr, &err) != 0) {
             i_error("%s: dracauth6() failed: %s", __FUNCTION__, err);
         }

--- a/drac-plugin.c
+++ b/drac-plugin.c
@@ -62,15 +62,15 @@ static void drac_mail_user_created(struct mail_user *user)
     const char *dractout_str;
     char *ep;
 
-    if (user->remote_ip == NULL) {
+    if (user->conn.remote_ip == NULL) {
         i_debug("%s Not a remote login", __FUNCTION__);
         return;
     }
 
     /* check address family */
-    if(IPADDR_IS_V4(user->remote_ip) || IPADDR_IS_V6(user->remote_ip)) {
+    if(IPADDR_IS_V4(user->conn.remote_ip) || IPADDR_IS_V6(user->conn.remote_ip)) {
         /* get remote IP address... uum... */
-        memcpy(&ip, user->remote_ip, sizeof(ip));
+        memcpy(&ip, user->conn.remote_ip, sizeof(ip));
 
         /* get DRAC server name */
         drachost = mail_user_plugin_getenv(user, "dracdserver");


### PR DESCRIPTION
The user struct has changed, remote_ip is now available as
conn.remote_ip.